### PR TITLE
Include Trend in the glucose reading

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,10 @@
+import { Trend } from "./types";
+
+export const TREND_MAP: Trend[] = [
+    Trend.NotComputable,
+    Trend.SingleDown,
+    Trend.FortyFiveDown,
+    Trend.Flat,
+    Trend.FortyFiveUp,
+    Trend.SingleUp,
+  ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,12 +270,34 @@ export interface RawGlucoseReading {
   isLow: boolean;
 }
 
+/**
+ * @description A parsed glucose reading from the Libre Link Up API.
+ */
 export interface GlucoseReading {
+  /**
+   * @description The timestamp of the glucose reading.
+   */
   timestamp: Date;
+  /**
+   * @description The value of the glucose reading in mg/dL.
+   */
   value: number;
+  /**
+   * @description The measurement color of the glucose reading. See {@link MeasurementColor}.
+   */
   measurementColor: MeasurementColor;
+  /**
+   * @description Whether the glucose reading is high, based on the patient's settings. Calculated by the library.
+   */
   isHigh: boolean;
+  /**
+   * @description Whether the glucose reading is low, based on the patient's settings. Calculated by the library.
+   */
   isLow: boolean;
+  /**
+   * @description The trend of the glucose reading. See {@link Trend}.
+   */
+  trend: Trend;
 }
 
 interface Ticket {
@@ -289,6 +311,15 @@ export enum MeasurementColor {
   Green = 1,
   Yellow = 2,
   Orange = 3,
+}
+
+export enum Trend {
+  'NotComputable' = 0,
+  'SingleDown' = 1,
+  'FortyFiveDown' = 2,
+  'Flat' = 3,
+  'FortyFiveUp' = 4,
+  'SingleUp' = 5,
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { RawGlucoseReading, LibreUser, GlucoseReading, MeasurementColor, LibreConnection } from "./types";
+import { TREND_MAP } from "./constants";
+import { RawGlucoseReading, LibreUser, GlucoseReading, MeasurementColor, LibreConnection, Trend } from "./types";
 
 /**
  * Parse a Libre User object.
@@ -36,6 +37,7 @@ export const parseGlucoseReading = (rawReading: RawGlucoseReading, connection: L
         measurementColor: rawReading.MeasurementColor as MeasurementColor,
         isHigh,
         isLow,
+        trend: getTrend(rawReading.TrendArrow)
     });
 
     return parsedReading;
@@ -51,3 +53,10 @@ export const parseGlucoseReading = (rawReading: RawGlucoseReading, connection: L
  * .sort(sortByTimestamp)
  */
 export const sortByTimestamp = (a: GlucoseReading, b: GlucoseReading) => a.timestamp.getTime() - b.timestamp.getTime();
+
+/**
+ * @description Get the trend of a set of glucose readings.
+ * @param trend The current trend.
+ * @param defaultTrend The default trend to use if trend is undefined.
+ */
+const getTrend = (trend: number | undefined, defaultTrend: Trend = Trend.Flat) => TREND_MAP[trend!] ?? defaultTrend;

--- a/tests/__snapshots__/client.test.ts.snap
+++ b/tests/__snapshots__/client.test.ts.snap
@@ -188,6 +188,7 @@ exports[`LibreLinkClient should successfully read data 1`] = `
   "isLow": "boolean",
   "measurementColor": "number",
   "timestamp": {},
+  "trend": "number",
   "value": "number",
 }
 `;


### PR DESCRIPTION
This PR will add the Trend property to the glucose reading. It is based on the TrendArrow property fetched from the Libre Link Up API.