### PR TITLE
✨ Add option to set lluVersion to individual LibreLinkClient instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ import { LibreLinkClient } from 'libre-link-unofficial-api';
 const client = new LibreLinkClient({ email: 'your-libre-link-up-email', password: 'your-libre-link-up-password' });
 ```
 
+#### Custom Libre Link Up Version or Patient ID.
+
+The llu version and patient ID can be passed directly to the LibreLinkClient.
+Useful in cases when the default values from the env variables are not sufficient.
+
+```js
+import { LibreLinkClient } from 'libre-link-unofficial-api';
+
+const client = new LibreLinkClient({ 
+    email: 'your-libre-link-up-email', 
+    password: 'your-libre-link-up-password',
+    lluVersion: '4.12.0', // Default derives from the environment variables.
+    patientId: '2b2b2b2b-2b2b-2b2b-2b2b-2b2b2b2b2b2b' // Default derives from the environment variables.
+});
+```
+
 ### Log into Libre Link Up
 ```js
 await client.login();

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ export class LibreLinkClient {
   private apiUrl = config.apiUrl;
   private accessToken: string | null = null;
   private patientId: string | null = config.patientId || null;
+  private lluVersion: string | undefined;
 
   // A cache for storing fetched data.
   private cache = new Map<string, any>();
@@ -20,6 +21,9 @@ export class LibreLinkClient {
 
     if(options?.patientId)
       this.patientId = options.patientId;
+
+    if(options?.lluVersion)
+      this.lluVersion = options.lluVersion;
 
     // Merge the options with the default options.
     this.options = { ...DEFAULT_OPTIONS, ...options };
@@ -303,7 +307,7 @@ export class LibreLinkClient {
   
       // Libre Link Up API headers
       product: 'llu.android',
-      version: config.lluVersion,
+      version: this.lluVersion || config.lluVersion,
   
       'accept-encoding': 'gzip',
       'cache-control': 'no-cache',
@@ -389,6 +393,7 @@ interface LibreLinkClientOptions {
   password?: string;
   patientId?: string;
   cache?: boolean;
+  lluVersion?: string;
 }
 
 const DEFAULT_OPTIONS: LibreLinkClientOptions = {


### PR DESCRIPTION
This pull request introduces the ability to customize the Libre Link Up version and patient ID directly when creating a `LibreLinkClient` instance. This enhancement is useful for scenarios where the default values from the environment variables are insufficient.

Enhancements to `LibreLinkClient`:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R93): Added documentation on how to pass custom `lluVersion` and `patientId` directly to the `LibreLinkClient` constructor.
* [`src/client.ts`](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R13): Updated the `LibreLinkClient` class to include `lluVersion` as an optional parameter in the constructor and to use it if provided.