### PR TITLE
Remove Typescript as a Peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,9 @@
   },
   "devDependencies": {
     "bun-types": "latest",
+    "typescript": "^5.8.3",
     "rimraf": "latest",
     "bun-bagel": "^1.0.8"
-  },
-  "peerDependencies": {
-    "typescript": "latest"
   },
   "files": [
     "dist/*.js",


### PR DESCRIPTION
It isn't necessarily required to have TypeScript or to even have TypeScript as a peer dependency to use this library. Having type files are still discoverable by people who use TypeScript