### PR TITLE
Add proper return type for fetchConnections method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { config } from "./config";
 import { GlucoseReading } from "./reading";
-import { LibreLinkUpEndpoints, LibreLoginResponse, LibreResponse, LibreRedirectResponse, LibreUser, LibreConnection, LibreConnectionResponse, LibreLogbookResponse } from "./types";
+import { LibreLinkUpEndpoints, LibreLoginResponse, LibreResponse, LibreRedirectResponse, LibreUser, LibreConnection, LibreConnectionResponse, LibreConnectionsResponse, LibreLogbookResponse } from "./types";
 import { encryptSha256, parseUser } from "./utils";
 
 /**
@@ -218,17 +218,17 @@ export class LibreLinkClient {
   /**
    * @description Get the connections from the Libre Link Up API.
    */
-  public async fetchConnections() {
+  public async fetchConnections(): Promise<LibreConnectionsResponse> {
     try {
       if(this.cache.has("connections"))
-        return this.cache.get("connections");
+        return this.cache.get("connections") as LibreConnectionsResponse;
 
       const headers = {
         "Account-Id": this.me?.id ? await encryptSha256(this.me.id) : "",
       };
 
       // Fetch the connections from the Libre Link Up API.
-      const connections = await this._fetcher(LibreLinkUpEndpoints.Connections, { headers });
+      const connections = await this._fetcher<LibreConnectionsResponse>(LibreLinkUpEndpoints.Connections, { headers });
 
       this.verbose(`Fetched ${connections?.data?.length} connections from Libre Link Up API.`, JSON.stringify(connections, null, 2));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,12 @@ export interface LibreLogbookResponse extends LibreResponse {
   ticket: Ticket;
 }
 
+export interface LibreConnectionsResponse extends LibreResponse {
+  status: number;
+  data: LibreConnection[];
+  ticket: Ticket;
+}
+
 export interface LibreActiveSensor {
   sensor: LibreSensor;
   device: LibreDevice;


### PR DESCRIPTION
## Summary

Added proper TypeScript return type for the `fetchConnections()` method to improve type safety and developer experience.

## Changes

Added `LibreConnectionsResponse` interface that properly types the response from the connections endpoint:

```typescript
export interface LibreConnectionsResponse extends LibreResponse {
  status: number;
  data: LibreConnection[];
  ticket: Ticket;
}
```

Updated `fetchConnections()` method to use this type:

```typescript
public async fetchConnections(): Promise<LibreConnectionsResponse> {
  // ... implementation
  const connections = await this._fetcher<LibreConnectionsResponse>(
    LibreLinkUpEndpoints.Connections, 
    { headers }
  );
  // ...
}
```

## Benefits

1. **Type Safety**: IDE and TypeScript can now properly infer the return type
2. **Better Autocomplete**: Developers get proper suggestions when working with connections data
3. **Type Checking**: Catches potential bugs at compile time
4. **Documentation**: Type definition serves as inline documentation for the API response structure

## Example Usage

```typescript
const client = new LibreLinkClient({ email: 'user@example.com', password: 'pass' });
await client.login();

const response = await client.fetchConnections();
// response is now properly typed as LibreConnectionsResponse
// IDE knows that response.data is LibreConnection[]
const connections = response.data;
connections.forEach(conn => {
  console.log(conn.firstName, conn.lastName); // Fully typed!
});
```

## Testing

- ✅ All existing tests pass (12 pass, 0 fail)
- ✅ TypeScript compilation successful
- ✅ No breaking changes - purely additive typing