### PR TITLE
fix: resolve Vite import errors and safely handle process.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
   "name": "libre-link-unofficial-api",
-  "module": "src/index.ts",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "version": "1.0.0-alpha.7",
   "description": "An unofficial API for Libre Link Up (glucose monitoring system/CGM)",

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,10 +19,13 @@ export class LibreLinkClient {
     if (!options?.email && !config.credentials.email)
       throw new Error("Libre Link Up credentials are missing.");
 
-    if(options?.patientId)
+    if (options?.apiUrl)
+      this.apiUrl = options.apiUrl;
+
+    if (options?.patientId)
       this.patientId = options.patientId;
 
-    if(options?.lluVersion)
+    if (options?.lluVersion)
       this.lluVersion = options.lluVersion;
 
     // Merge the options with the default options.
@@ -33,7 +36,7 @@ export class LibreLinkClient {
    * @description Get the user data. Only available after logging in.
    */
   public get me(): LibreUser | null {
-    if(!this.cache.has("user")) {
+    if (!this.cache.has("user")) {
       console.warn("User data is not available. Please log in first.");
       return null;
     }
@@ -47,10 +50,10 @@ export class LibreLinkClient {
   public async login(): Promise<LibreLoginResponse> {
     const email = this.options?.email || config.credentials.email;
     const password = this.options?.password || config.credentials.password;
-    
+
     try {
       type LoginResponse = LibreLoginResponse | LibreRedirectResponse;
-      
+
       // Attempt to login to the Libre Link Up API.
       const response = await this._fetcher<LoginResponse>(LibreLinkUpEndpoints.Login, {
         method: "POST",
@@ -59,21 +62,21 @@ export class LibreLinkClient {
           password
         }),
       });
-  
+
       // If the status is 2, means the credentials are invalid.
-      if(response.status === 2)
+      if (response.status === 2)
         throw new Error("Invalid credentials. Please ensure that the email and password work with the LibreLinkUp app.");
 
-      if(!response.data) 
+      if (!response.data)
         throw new Error("No data returned from Libre Link Up API.");
 
       // If the response contains a redirect, update the region and try again.
-      if("redirect" in response.data) {
+      if ("redirect" in response.data) {
         this.verbose("Redirecting to region:", response.data.region);
         const regionUrl = await this.findRegion(response.data.region);
         // Update the API URL with the region url.
         this.apiUrl = regionUrl;
-        
+
         return await this.login();
       }
 
@@ -86,7 +89,7 @@ export class LibreLinkClient {
       this.verbose("Logged into Libre Link Up API.");
 
       return response as LibreLoginResponse;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -104,7 +107,7 @@ export class LibreLinkClient {
 
       // Parse and return the latest glucose item from the response.
       return new GlucoseReading(response.data?.connection.glucoseItem, response.data.connection);
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -122,7 +125,7 @@ export class LibreLinkClient {
       const list = response.data.graphData.map((item) => new GlucoseReading(item, response.data.connection));
 
       return list;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -140,7 +143,7 @@ export class LibreLinkClient {
       const list = response.data.map((item) => new GlucoseReading(item));
 
       return list;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -159,7 +162,7 @@ export class LibreLinkClient {
         yield reading;
         await new Promise(resolve => setTimeout(resolve, intervalMs));
       } catch (error) {
-        console.error("Error fetching reading:", error); 
+        console.error("Error fetching reading:", error);
         throw error;
       }
     }
@@ -182,7 +185,7 @@ export class LibreLinkClient {
       this.verbose("Fetched reading from Libre Link Up API.", JSON.stringify(response, null, 2));
 
       return response;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -207,7 +210,7 @@ export class LibreLinkClient {
       this.verbose("Fetched logbook from Libre Link Up API.", JSON.stringify(response, null, 2));
 
       return response;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -220,7 +223,7 @@ export class LibreLinkClient {
    */
   public async fetchConnections() {
     try {
-      if(this.cache.has("connections"))
+      if (this.cache.has("connections"))
         return this.cache.get("connections");
 
       const headers = {
@@ -232,12 +235,12 @@ export class LibreLinkClient {
 
       this.verbose(`Fetched ${connections?.data?.length} connections from Libre Link Up API.`, JSON.stringify(connections, null, 2));
 
-      if(!!connections?.data?.length)
+      if (!!connections?.data?.length)
         // Cache the connections for future use.
         this.setCache("connections", connections);
 
       return connections;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -252,19 +255,19 @@ export class LibreLinkClient {
     const connections = await this.fetchConnections();
 
     // If there are no connections, throw an error.
-    if(!connections.data?.length)
+    if (!connections.data?.length)
       throw new Error("No connections found. Please ensure that you have a connection with the LibreLinkUp app.");
 
     // Get the patient ID from the connections, or fallback to the first connection.
 
     let patientId = connections.data[0].patientId;
 
-    if(this.patientId)
+    if (this.patientId)
       connections.data.find(
         (connection: LibreConnection) => connection.patientId === this.patientId
       )?.patientId;
 
-    if(!patientId)
+    if (!patientId)
       throw new Error(`Patient ID not found in connections. (${this.patientId})`);
 
     this.verbose("Using patient ID:", patientId);
@@ -283,11 +286,11 @@ export class LibreLinkClient {
       // Find the region in the response.
       const lslApi = response.data?.regionalMap[region]?.lslApi;
 
-      if(!lslApi)
+      if (!lslApi)
         throw new Error("Region not found in Libre Link Up API.");
 
       return lslApi;
-    } catch(err) {
+    } catch (err) {
       const error = err as Error;
 
       console.error(error);
@@ -304,17 +307,17 @@ export class LibreLinkClient {
     const headers = new Headers({
       ...options.headers,
       Authorization: this.accessToken ? `Bearer ${this.accessToken}` : "",
-  
+
       // Libre Link Up API headers
       product: 'llu.android',
       version: this.lluVersion || config.lluVersion,
-  
+
       'accept-encoding': 'gzip',
       'cache-control': 'no-cache',
       connection: 'Keep-Alive',
       'content-type': 'application/json',
     });
-    
+
     const requestOptions: FetchRequestInit = Object.freeze({
       ...options,
       headers
@@ -333,10 +336,10 @@ export class LibreLinkClient {
       );
 
       if (!response.ok) {
-        const errorPayload = await response.json(); 
+        const errorPayload = await response.json();
         const errorMessage = errorPayload?.message ?? JSON.stringify(errorPayload, null, 2)
-        
-        if(response.status === 429)
+
+        if (response.status === 429)
           throw new Error(`Too many requests. Please wait before trying again. ${errorMessage}`);
 
         throw new Error(
@@ -366,7 +369,7 @@ export class LibreLinkClient {
    * @param args
    */
   private verbose(...args: any[]) {
-    if (config.verbose) console.log(...args);
+    if (this.options.verbose ?? config.verbose) console.log(...args);
   }
 
   /**
@@ -375,7 +378,7 @@ export class LibreLinkClient {
    * @param value The value to cache.
    */
   private setCache(key: string, value: any) {
-    if(!this.options.cache) return;
+    if (!this.options.cache) return;
 
     this.cache.set(key, value);
   }
@@ -394,6 +397,8 @@ interface LibreLinkClientOptions {
   patientId?: string;
   cache?: boolean;
   lluVersion?: string;
+  apiUrl?: string;
+  verbose?: boolean;
 }
 
 const DEFAULT_OPTIONS: LibreLinkClientOptions = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,16 @@
+const getEnv = (key: string) => {
+    if (typeof process !== "undefined" && process?.env) {
+        return process.env[key];
+    }
+    return undefined;
+};
 
-const LIBRE_LINK_API_URL = process?.env?.LIBRE_LINK_API_URL ?? "https://api-us.libreview.io";
-const LIBRE_LINK_EMAIL = process?.env?.LIBRE_LINK_EMAIL;
-const LIBRE_LINK_PASSWORD = process?.env?.LIBRE_LINK_PASSWORD;
-const LIBRE_LINK_UP_VERSION = process?.env?.LIBRE_LINK_UP_VERSION ?? "4.16.0";
-const LIBRE_LINK_PATIENT_ID = process?.env?.LIBRE_LINK_PATIENT_ID;
-const VERBOSE = process?.env?.VERBOSE === "true";
+const LIBRE_LINK_API_URL = getEnv("LIBRE_LINK_API_URL") ?? "https://api-us.libreview.io";
+const LIBRE_LINK_EMAIL = getEnv("LIBRE_LINK_EMAIL");
+const LIBRE_LINK_PASSWORD = getEnv("LIBRE_LINK_PASSWORD");
+const LIBRE_LINK_UP_VERSION = getEnv("LIBRE_LINK_UP_VERSION") ?? "4.16.0";
+const LIBRE_LINK_PATIENT_ID = getEnv("LIBRE_LINK_PATIENT_ID");
+const VERBOSE = getEnv("VERBOSE") === "true";
 
 /**
  * @description Configuration for the Libre Link Up API client.

--- a/tests-int/client.test.ts
+++ b/tests-int/client.test.ts
@@ -3,7 +3,10 @@ import { LibreLinkClient } from '../src';
 import { mapObjectPropertiesToTypes } from "./utils";
 
 describe('Libre Link Up API Integrity', () => {
-  const client: LibreLinkClient = new LibreLinkClient();
+  const client: LibreLinkClient = new LibreLinkClient({
+    email: process.env.LIBRE_LINK_EMAIL || "test@example.com",
+    password: process.env.LIBRE_LINK_PASSWORD || "password123",
+  });
 
   // Wait for a couple of seconds between tests to avoid 429 too many requests errors.
   beforeEach(() => new Promise((resolve) => setTimeout(resolve, 5000)));
@@ -42,7 +45,7 @@ describe('Libre Link Up API Integrity', () => {
     const glucoseReadings = await client.logbook();
 
     expect(glucoseReadings).toBeTruthy();
-    if(glucoseReadings.length > 0) {
+    if (glucoseReadings.length > 0) {
       expect(glucoseReadings[0]).toBeTruthy();
       expect(typeof glucoseReadings[0].value).toBe("number");
       expect(glucoseReadings[0].timestamp instanceof Date).toBe(true);

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -4,7 +4,10 @@ import { LibreLinkConnectionsMock, LibreLinkLoginMock, LibreLinkReadMock } from 
 import { mock, clearMocks } from 'bun-bagel';
 
 describe('LibreLinkClient', () => {
-  const client: LibreLinkClient = new LibreLinkClient();
+  const client: LibreLinkClient = new LibreLinkClient({
+    email: process.env.LIBRE_LINK_EMAIL || "test@example.com",
+    password: process.env.LIBRE_LINK_PASSWORD || "password123"
+  });
 
   afterEach(() => {
     // Clear pending mocks after each test
@@ -18,7 +21,7 @@ describe('LibreLinkClient', () => {
   test('should successfully login', async () => {
     // Mock the fetch method
     mock('llu/auth/login', { data: { data: LibreLinkLoginMock }, method: "POST" });
-    
+
     await client.login();
 
     expect(client.me).toBeTruthy();


### PR DESCRIPTION
## Description
This PR addresses issues where the library crashed or failed to resolve when imported in modern browser-based environments like Vite or React.

### Changes Made
- **Fix Vite Import Error**: Removed the `"module": "src/index.ts"` entry from [package.json](cci:7://file:///e:/gitbun/libre-link-unofficial-api/package.json:0:0-0:0) that was causing ESM resolution failures, and replaced it with a proper `"exports"` map to correctly route to compiled [.ts](cci:7://file:///e:/gitbun/libre-link-unofficial-api/src/utils.ts:0:0-0:0) declarations and `.js` bundles.
- **Safe Environment Variables**: Replaced direct hardcoded `process.env` references in [config.ts](cci:7://file:///e:/gitbun/libre-link-unofficial-api/src/config.ts:0:0-0:0) with a safe [getEnv](cci:1://file:///e:/gitbun/libre-link-unofficial-api/src/config.ts:0:0-5:2) function. It now smoothly falls back when `process` is undefined instead of throwing a critical ReferenceError.
- **Extended Options**: Added `apiUrl` and [verbose](cci:1://file:///e:/gitbun/libre-link-unofficial-api/src/client.ts:366:2-372:3) fallback properties directly into the [LibreLinkClientOptions](cci:2://file:///e:/gitbun/libre-link-unofficial-api/src/client.ts:393:0-401:1) interface, allowing developers to cleanly pass config keys via the constructor without needing Node environment processes.
- **Updated Tests**: Refactored the unit and integration testing suite to explicitly configure [LibreLinkClient](cci:2://file:///e:/gitbun/libre-link-unofficial-api/src/client.ts:8:0-391:1) instances with mock credentials, ensuring tests continue to pass with the new fallback behavior.

## How to Test
1. Clone the branch and build the bundle (`npm run build`).
2. Run tests to see they pass successfully (`npm run test`).
3. Import the output `dist` files inside a fresh Vite template (e.g., `npm create vite@latest`) and verify the library doesn't throw a module or `process` error in the browser console.
